### PR TITLE
Remove allowed file types from image uploader configuration

### DIFF
--- a/src/auth/profielfoto.js
+++ b/src/auth/profielfoto.js
@@ -9,7 +9,6 @@ const uploadRouter = {
     image: {
       maxFileSize: "4MB",
       maxFileCount: 1,
-      allowedFileTypes: ["image/jpeg", "image/png", "image/webp"],
     },
   })
     .middleware(async ({ req, res }) => {


### PR DESCRIPTION
Eliminate the restriction on allowed file types in the image uploader to enhance flexibility.