### PR TITLE
Initialize UTApi with API token from environment variables

### DIFF
--- a/src/modules/uploadthing.js
+++ b/src/modules/uploadthing.js
@@ -2,6 +2,8 @@ const { UTApi } = require('uploadthing/server');
 
 require('dotenv').config();
 
-const utapi = new UTApi();
+const utapi = new UTApi({
+    token: process.env.UPLOADTHING_API_TOKEN,
+});
 
 module.exports = utapi;


### PR DESCRIPTION
Configure UTApi to use the API token sourced from environment variables for improved security and flexibility.