### PR TITLE
Set defaultKeyType to 'image' in UTApi initialization

### DIFF
--- a/src/modules/uploadthing.js
+++ b/src/modules/uploadthing.js
@@ -4,6 +4,7 @@ require('dotenv').config();
 
 const utapi = new UTApi({
     token: process.env.UPLOADTHING_API_TOKEN,
+    defaultKeyType: 'image',
 });
 
 module.exports = utapi;


### PR DESCRIPTION
Ensure that the default key type is correctly set to 'image' during the initialization of the UTApi.