### PR TITLE
Allow refresh token from request body or cookies

### DIFF
--- a/src/auth/refresh.js
+++ b/src/auth/refresh.js
@@ -4,7 +4,7 @@ const jwt = require('jsonwebtoken');
 const router = express.Router();
 
 router.post('/', (req, res, next) => {
-    const refreshToken = req.cookies.refreshToken;
+    const refreshToken = req.body.refreshToken || req.cookies.refreshToken;
 
     if (!refreshToken) {
         return res.status(401).json({ message: 'No refresh token provided' });


### PR DESCRIPTION
Enable the refresh token to be provided either in the request body or as a cookie, improving flexibility in token handling.