### PR TITLE
Add 'onlyNew' parameter for filtering in discover endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -637,6 +637,15 @@ paths:
             default: true
           description: >
             If true (default), results are weighted by functie, opleiding and skills. If false, companies that want the student's functie are listed first, then opleiding, then others, all ordered by skill matches.
+        - name: onlyNew
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: >
+            If true, only returns companies that have not been matched with the student before.
+            This is used to avoid showing the same companies multiple times.
       responses:
         '200':
           description: List of bedrijven ordered by relevance
@@ -726,6 +735,15 @@ paths:
             default: true
           description: >
             If true (default), results are weighted by functie, opleiding and skills. If false, students with matching functie are listed first, then opleiding, then others, all ordered by skill matches.
+        - name: onlyNew
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: >
+            If true, only returns students that have not been matched with the bedrijf before.
+            This is used to avoid showing the same students multiple times.
       responses:
         '200':
           description: List of studenten ordered by relevance

--- a/src/routes/discover.js
+++ b/src/routes/discover.js
@@ -20,11 +20,13 @@ router.get('/bedrijven', passport.authenticate('jwt', { session: false }), async
     // Check if suggestion parameter is provided
     const suggestions = req.query.suggestions === undefined ? true : req.query.suggestions === 'true';
 
+    const onlyNew = req.query.onlyNew === undefined ? false : req.query.onlyNew === 'true';
+
     if (!studentId) {
         return res.status(400).json({ error: 'Student ID is required' });
     }
     try {
-        const rows = await getDiscoverBedrijven(studentId, suggestions);
+        const rows = await getDiscoverBedrijven(studentId, suggestions, onlyNew);
         res.json(rows);
     } catch (error) {
         console.error('Error in /discover/bedrijven:', error);
@@ -46,11 +48,13 @@ router.get('/studenten', passport.authenticate('jwt', { session: false }), async
     // Check if suggestion parameter is provided
     const suggestions = req.query.suggestions === undefined ? true : req.query.suggestions === 'true';
 
+    const onlyNew = req.query.onlyNew === undefined ? false : req.query.onlyNew === 'true';
+
     if (!bedrijfId) {
         return res.status(400).json({ error: 'Bedrijf ID is required' });
     }
     try {
-        const rows = await getDiscoverStudenten(bedrijfId, suggestions);
+        const rows = await getDiscoverStudenten(bedrijfId, suggestions, onlyNew);
         res.json(rows);
     } catch (error) {
         console.error('Error in /discover/studenten:', error);


### PR DESCRIPTION
Introduce an 'onlyNew' query parameter to the /discover/bedrijven and /discover/studenten endpoints, allowing users to filter out previously matched results. Update the corresponding functions to handle this new filtering option.